### PR TITLE
docs: clarify PR title-based versioning and pipeline approval gates

### DIFF
--- a/.github/SEMANTIC_RELEASE_IMPLEMENTATION.md
+++ b/.github/SEMANTIC_RELEASE_IMPLEMENTATION.md
@@ -58,7 +58,11 @@ Updated `release.yml` with the following semantic-release steps for non-Terrafor
 
 ## Configuration Details
 
-### Commit Patterns
+### Version Bump Determination
+
+**IMPORTANT**: Version bumps are determined by the **PR title**, not individual commit messages. When the pipeline auto-merges a PR, it creates a squash commit using the PR title as the commit message. This commit message is analyzed to determine the version bump type.
+
+### PR Title Patterns
 
 - **Major**: `feat!:`, `fix!:`, `refactor!:`, etc. (with breaking change indicator)
 - **Minor**: `feat:` (new features)

--- a/README.md
+++ b/README.md
@@ -316,8 +316,8 @@ This repository uses a multi-stage, automated CI/CD pipeline to ensure code qual
 2. **Change Detection**: Determines if the PR changes a Terraform module or only non-module files.
 3. **Validation**: Runs comprehensive policy, linting, formatting, documentation, and security checks.
 4. **Testing**: Executes full test suite (automatic for internal, manual approval for external contributors).
-5. **Approval & Merge**: Maintainers review and approve. PRs are auto-merged after approval.
-6. **Release**: Automated versioning and changelog for both Terraform and non-Terraform code.
+5. **Approval & Merge**: Maintainers review and approve. PRs are auto-merged after approval (never merge manually).
+6. **Release**: Automated versioning (based on PR title) and changelog for both Terraform and non-Terraform code.
 
 See [Workflow Logic](docs/WORKFLOW_LOGIC.md) and [Main Validation SDLC Guide](docs/main-validation-sdlc.md) for full details.
 
@@ -327,11 +327,14 @@ See [Workflow Logic](docs/WORKFLOW_LOGIC.md) and [Main Validation SDLC Guide](do
 - Follow [module structure requirements](docs/terraform-module-structure.md) and [module policies](docs/terraform-module-policies.md).
 - Implement comprehensive tests using [Terraform Terratest Framework](https://github.com/caylent-solutions/terraform-terratest-framework).
 - Validate and test locally before submitting a PR.
-- Use conventional commit messages (`feat:`, `fix:`, etc.).
+- **Format your PR title** with conventional commit prefix (`feat:`, `fix:`, etc.) - this determines the version bump.
+- **Never manually merge PRs** - the pipeline automatically merges after approval.
 - Automated validation, testing, and release via CI/CD.
 
 ### For Non-Terraform Code
 - Linting, tests, and policy checks as appropriate.
+- **Format your PR title** with conventional commit prefix (`feat:`, `fix:`, etc.) - this determines the version bump.
+- **Never manually merge PRs** - the pipeline automatically merges after approval.
 - Uses `python-semantic-release` for versioning and changelog.
 - Automated validation and release via CI/CD.
 
@@ -345,6 +348,7 @@ See [docs/CONTRIBUTING.md](docs/CONTRIBUTING.md) for detailed instructions.
 
 ### Contributor Guides
 - [Contributing Guidelines](docs/CONTRIBUTING.md) - How to contribute and SDLC process
+- [PR Title-Based Versioning](docs/pr-title-versioning.md) - How PR titles determine version bumps
 - [Workflow Logic Documentation](docs/WORKFLOW_LOGIC.md) - Detailed CI/CD flow explanation
 - [Main Validation SDLC Guide](docs/main-validation-sdlc.md) - SDLC process for workflow maintenance
 - [AWS Authentication Integration](docs/aws-authentication-integration.md) - How AWS authentication works with GitHub Actions for module testing

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -62,37 +62,52 @@ git push origin feature/my-module
 ### 1. Development Phase
 - Follow [module structure requirements](terraform-module-structure.md)
 - Implement comprehensive tests using [Terraform Terratest Framework](https://github.com/caylent-solutions/terraform-terratest-framework)
-- Use conventional commit messages (`feat:`, `fix:`, `docs:`, etc.)
+- Use conventional commit messages for your local commits (optional - only PR title matters for versioning)
+- **Format your PR title** with conventional commit prefix (`feat:`, `fix:`, `docs:`, etc.) - this determines the version bump
 - Validate locally before submitting
 
 ### 2. Pull Request Submission
+- **Format PR title** with conventional commit prefix (`feat:`, `fix:`, etc.) - this determines the version bump
+- **Never manually merge PRs** - the pipeline handles all merges automatically
 - **PR Detection**: System detects Terraform module vs non-Terraform changes
 - **Security Scanning**: CodeQL analysis starts immediately (parallel to validation)
 - **Validation**: Comprehensive policy and quality checks
 
 ### 3. Testing Phase
 - **Internal Contributors**: Tests execute automatically after validation
-- **External Contributors**: Tests require manual approval from Caylent maintainer for security
+- **External Contributors**: Tests require approval via `external-contributor-test-approval` environment
 
-### 4. Review and Approval
+### 4. Main Validation Workflow
+- PR validation triggers main-validation workflow
+- Routes to appropriate merge approval job based on contributor type
+
+### 5. Merge Approval Gate
+- Requires approval via GitHub Environment:
+  - Internal (non-self-approve): `merge-approval` environment
+  - Internal (self-approve): `merge-approval` environment (manual approval still required)
+  - External: `external-contributor-merge-approval` environment
 - Slack notifications sent to code owners
-- Code owners review and must explicitly approve before merge
 
-### 5. Merge Process
-- System automatically merges PR after approval (squash merge)
+### 6. Merge Process
+- **System automatically merges PR after approval** (squash merge using PR title as commit message)
+- **Never manually merge PRs through GitHub UI** - the pipeline handles all merges
 - Feature branch deleted automatically
 
-### 6. Post-Merge Validation
+### 7. Post-Merge Validation
 - All validation checks re-run on merged code
 - Additional security scanning on main branch
 
-### 7. Release Preparation
-- Manual QA certification required from code owners
-- Authorizes semantic version release
+### 8. QA Certification Gate
+- Requires approval via `qa-certification` environment
+- Slack notification sent after post-merge validation passes
 
-### 8. Automated Release
-- **Terraform Modules**: Individual semantic versioning per module
-- **Non-Terraform**: Repository-wide semantic versioning
+### 9. Release Approval Gate
+- Requires approval via `qa-certification` environment
+- Triggers release workflow upon approval
+
+### 10. Automated Release
+- **Terraform Modules**: Individual semantic versioning per module (based on PR title)
+- **Non-Terraform**: Repository-wide semantic versioning (based on PR title)
 - Automatic changelog generation and GitHub release creation
 
 ---
@@ -132,8 +147,13 @@ This repository uses a multi-stage, automated CI/CD pipeline to ensure code qual
 2. **Change Detection**: Determines if the PR changes a Terraform module or only non-module files.
 3. **Validation**: Runs comprehensive policy, linting, formatting, documentation, and security checks.
 4. **Testing**: Executes full test suite (automatic for internal, manual approval for external contributors).
-5. **Approval & Merge**: Maintainers review and approve. PRs are auto-merged after approval.
-6. **Release**: Automated versioning and changelog for both Terraform and non-Terraform code.
+5. **Main Validation**: Triggers main-validation workflow with merge approval routing.
+6. **Merge Approval**: Requires environment approval (varies by contributor type).
+7. **Auto-Merge**: Pipeline merges PR using squash merge with PR title as commit message.
+8. **Post-Merge Validation**: Re-runs all tests on merged code.
+9. **QA Certification**: Requires environment approval before release.
+10. **Release Approval**: Requires environment approval to trigger release.
+11. **Release**: Automated versioning (based on PR title) and changelog.
 
 See [WORKFLOW_LOGIC.md](WORKFLOW_LOGIC.md) and [main-validation-sdlc.md](main-validation-sdlc.md) for full details.
 
@@ -260,6 +280,7 @@ All modules must follow the [required structure](terraform-module-structure.md) 
 - [Module Structure](terraform-module-structure.md)
 - [Module Policies](terraform-module-policies.md)
 - [Testing Requirements](terraform-module-testing.md)
+- [PR Title-Based Versioning](pr-title-versioning.md)
 - [Complete Workflow Logic](WORKFLOW_LOGIC.md)
 - [Main Validation SDLC Guide](main-validation-sdlc.md)
 
@@ -345,11 +366,13 @@ Internal contributors have direct repository access with streamlined workflow:
    - Run validation (from repo root): `make module-validate MODULE_PATH=providers/aws/primitives/your-module-name MODULE_TYPE=primitive`
    - Run tests (from module dir): `make test` (all tests), `make test-common` (common tests)
 
-### Conventional Commit Message Prefixes and Version Bumps
+### PR Title Format and Version Bumps
 
-The following commit prefixes and version bump rules apply to both Terraform module changes and non-Terraform changes in this repository.
+**IMPORTANT**: Version bumps are determined by the **PR title**, not individual commit messages. When the pipeline auto-merges your PR, it creates a squash commit using the PR title as the commit message. This commit message is what determines the version bump type.
 
-This repository uses [Conventional Commits](https://www.conventionalcommits.org/) for automated versioning and changelog generation. The type of version bump is determined by the commit message prefix:
+The following PR title prefixes and version bump rules apply to both Terraform module changes and non-Terraform changes in this repository.
+
+This repository uses [Conventional Commits](https://www.conventionalcommits.org/) for automated versioning and changelog generation. The type of version bump is determined by the **PR title prefix**:
 
 | Prefix Example      | Version Bump | Description                                 |
 |--------------------|--------------|---------------------------------------------|
@@ -372,5 +395,7 @@ This repository uses [Conventional Commits](https://www.conventionalcommits.org/
 | `refactor:`        | Patch        | Refactoring (non-breaking)                  |
 | `test:`            | Patch        | Test-related change                         |
 
-- Use the appropriate prefix for your commit messages to ensure correct versioning.
+- **Use the appropriate prefix for your PR title** to ensure correct versioning.
+- Individual commit messages within the PR do not affect versioning.
+- The pipeline automatically merges approved PRs - **never merge PRs manually through the GitHub UI**.
 - See `.github/SEMANTIC_RELEASE_IMPLEMENTATION.md` for full details.

--- a/docs/WORKFLOW_LOGIC.md
+++ b/docs/WORKFLOW_LOGIC.md
@@ -262,6 +262,12 @@ See [Main Validation Script Documentation](scripts/main-validation.md) for compl
 
 ## Key Decision Points
 
+### PR Title Requirements:
+- Must follow conventional commit format (`feat:`, `fix:`, etc.)
+- Determines version bump type during release
+- Becomes the squash commit message when auto-merged
+- Individual commit messages within PR do not affect versioning
+
 ### Module Detection Logic:
 - Analyzes changed files in PR
 - Determines if changes affect Terraform modules
@@ -288,6 +294,7 @@ See [Main Validation Script Documentation](scripts/main-validation.md) for compl
 - Security scans complete
 - Environment approval received (via GitHub Environment protection rules)
 - Contributor type verified
+- **PR title** used as squash commit message (determines version bump)
 
 ### GitHub Environment Protection Rules:
 The workflows use GitHub Environments for approval gates instead of issue-based manual approvals:

--- a/docs/main-validation-sdlc.md
+++ b/docs/main-validation-sdlc.md
@@ -179,8 +179,8 @@ For each scenario:
 
 ### Merge Strategy
 - **Squash merge into main** (required)
-- **Never use CLI merge** - always use GitHub UI to ensure hooks and protections run
-- **Merge commit message** must be descriptive and include issue/ticket references
+- **Never manually merge PRs** - the pipeline automatically handles all merges after approval
+- **PR title** becomes the merge commit message and determines version bump
 
 ### Post-Merge Actions
 - Monitor first few real workflow executions
@@ -219,8 +219,8 @@ Merges to `main` that modify `main-validation.yml` will:
 - **Git history** serves as version control
 - **Tag major changes** with descriptive Git tags: `workflow-v1.2.0`
 
-### Commit Message Standards
-Use [Conventional Commits](https://www.conventionalcommits.org/) format:
+### PR Title Standards
+Use [Conventional Commits](https://www.conventionalcommits.org/) format for PR titles:
 
 ```bash
 feat(validation): add dry run mode for safe testing
@@ -229,13 +229,16 @@ refactor(validation): improve merge routing logic
 docs(validation): update SDLC process documentation
 ```
 
-### Change Categories
-- **feat**: New features or capabilities
-- **fix**: Bug fixes and corrections
-- **refactor**: Code improvements without functional changes
-- **docs**: Documentation updates
-- **perf**: Performance improvements
-- **security**: Security-related changes
+**IMPORTANT**: The PR title determines the version bump type, not individual commit messages.
+
+### Change Categories (for PR titles)
+- **feat**: New features or capabilities (minor version bump)
+- **fix**: Bug fixes and corrections (patch version bump)
+- **refactor**: Code improvements without functional changes (patch version bump)
+- **docs**: Documentation updates (patch version bump)
+- **perf**: Performance improvements (minor version bump)
+- **security**: Security-related changes (patch version bump)
+- **feat!**, **fix!**, etc.: Breaking changes (major version bump)
 
 ---
 

--- a/docs/pr-title-versioning.md
+++ b/docs/pr-title-versioning.md
@@ -1,0 +1,152 @@
+# PR Title-Based Versioning
+
+## Overview
+
+This repository uses **PR titles** (not individual commit messages) to determine semantic version bumps during the automated release process.
+
+## How It Works
+
+1. **Developer creates PR** with conventional commit-formatted title
+2. **PR validation runs** - validates, tests, and analyzes contributor type
+3. **Tests execute** - internal: automatic, external: requires `external-contributor-test-approval` environment approval
+4. **Main validation triggered** - PR validation triggers main-validation workflow
+5. **Merge approval gate** - requires approval via GitHub Environment:
+   - Internal (non-self-approve): `merge-approval` environment
+   - Internal (self-approve): `merge-approval` environment (manual approval still required)
+   - External: `external-contributor-merge-approval` environment
+6. **Pipeline auto-merges** - squash merge using PR title as commit message
+7. **Post-merge validation** - re-runs all tests on merged code
+8. **QA certification gate** - requires approval via `qa-certification` environment
+9. **Release approval gate** - requires approval via `qa-certification` environment (triggers release workflow)
+10. **Release workflow runs** - analyzes commit message (PR title) to determine version bump
+11. **Version tagged** - creates tag based on PR title prefix
+
+## Why PR Titles?
+
+When the pipeline auto-merges a PR, it performs a **squash merge** that combines all commits into a single commit. The commit message for this squash commit is the **PR title**. Since semantic versioning tools analyze commit messages on the main branch, only the PR title matters for version determination.
+
+## PR Title Format
+
+Use [Conventional Commits](https://www.conventionalcommits.org/) format:
+
+```
+<type>[optional scope]: <description>
+
+Examples:
+feat: add new S3 encryption option
+fix: resolve IAM policy attachment issue
+feat!: change module input variable names (breaking change)
+docs: update README with new examples
+```
+
+## Version Bump Rules
+
+| PR Title Prefix | Version Bump | Example |
+|----------------|--------------|---------|
+| `feat!:`, `fix!:`, etc. | **Major** (breaking) | `v1.2.3` → `v2.0.0` |
+| `feat:` | **Minor** (feature) | `v1.2.3` → `v1.3.0` |
+| `fix:`, `docs:`, `chore:`, etc. | **Patch** (fix) | `v1.2.3` → `v1.2.4` |
+
+### Supported Prefixes
+
+**Major Version Bump** (breaking changes):
+- Any prefix with `!:` (e.g., `feat!:`, `fix!:`, `refactor!:`)
+- Footer contains `BREAKING CHANGE`
+
+**Minor Version Bump** (new features):
+- `feat:` - New feature
+- `perf:` - Performance improvement
+- `build:` - Build system change
+- `revert:` - Revert commit
+- `release:` - Release commit
+- `module:` - Module-level change
+- `meta:` - Metadata change
+- `ci:` - CI/CD change
+
+**Patch Version Bump** (fixes):
+- `fix:` - Bug fix
+- `chore:` - Chore/maintenance
+- `docs:` - Documentation change
+- `style:` - Code style change
+- `refactor:` - Refactoring (non-breaking)
+- `test:` - Test-related change
+
+## Important Rules
+
+### ✅ DO
+
+- **Format your PR title** with a conventional commit prefix
+- **Choose the correct prefix** based on the type of change
+- **Use `!:` for breaking changes** (e.g., `feat!:`, `fix!:`)
+- **Let the pipeline merge** your PR automatically after approval
+
+### ❌ DON'T
+
+- **Don't manually merge PRs** through the GitHub UI
+- **Don't rely on individual commit messages** for versioning
+- **Don't use non-standard prefixes** in PR titles
+- **Don't merge without a proper PR title**
+
+## Examples
+
+### Good PR Titles
+
+```
+feat: add support for KMS encryption
+fix: resolve race condition in module initialization
+feat!: remove deprecated input variables
+docs: add examples for advanced use cases
+chore: update dependencies to latest versions
+refactor: simplify IAM policy logic
+```
+
+### Bad PR Titles
+
+```
+Update code                          ❌ No conventional commit prefix
+Added new feature                    ❌ Not in conventional format
+WIP: testing changes                 ❌ Not ready for merge
+Merge pull request #123              ❌ Generic merge message
+```
+
+## Workflow Integration
+
+### For Terraform Modules
+
+1. PR title determines the module version bump
+2. Each module is versioned independently
+3. Release creates a tag like `providers/aws/primitives/s3/v1.2.3`
+
+### For Non-Terraform Code
+
+1. PR title determines the repository version bump
+2. Repository-wide semantic versioning
+3. Release creates a tag like `v1.2.3`
+
+## Troubleshooting
+
+### My PR was merged but no version bump occurred
+
+- Check if your PR title had a valid conventional commit prefix
+- Verify the prefix type matches the expected version bump
+- Review the release workflow logs for errors
+
+### I need to change the version bump type
+
+- The PR title is set when you create the PR
+- You can edit the PR title before it's merged
+- Once merged, the version is determined and cannot be changed
+
+### What if I made a mistake in the PR title?
+
+- Edit the PR title before approval/merge
+- If already merged, create a new PR with the correct changes
+- Contact maintainers if a version needs to be corrected
+
+## Additional Resources
+
+- [Conventional Commits Specification](https://www.conventionalcommits.org/)
+- [Semantic Versioning](https://semver.org/)
+- [Contributing Guidelines](CONTRIBUTING.md)
+- [Workflow Logic](WORKFLOW_LOGIC.md)
+- [Semantic Release Implementation](.github/SEMANTIC_RELEASE_IMPLEMENTATION.md)


### PR DESCRIPTION
## Summary

Updates all documentation to accurately reflect how versioning and approvals work in the pipeline.

## Changes

- **PR Title-Based Versioning**: Clarified that PR titles (not individual commit messages) determine version bumps since the pipeline creates squash commits using PR titles
- **Pipeline Auto-Merge**: Documented that developers should never manually merge PRs - the pipeline handles all merges automatically
- **Approval Gates**: Corrected all documentation to show approvals happen via GitHub Environments, not PR reviews:
  - `external-contributor-test-approval` for external test execution
  - `merge-approval` for internal contributor merges
  - `external-contributor-merge-approval` for external contributor merges
  - `qa-certification` for QA certification and release approval
- **Complete Workflow**: Updated SDLC flow to show complete 11-step process from PR creation to release
- **New Guide**: Added comprehensive `docs/pr-title-versioning.md` guide

## Files Changed

- `.github/SEMANTIC_RELEASE_IMPLEMENTATION.md`
- `README.md`
- `docs/CONTRIBUTING.md`
- `docs/WORKFLOW_LOGIC.md`
- `docs/main-validation-sdlc.md`
- `docs/pr-title-versioning.md` (new)

## Testing

Documentation changes only - no code changes.