### PR TITLE
fix: alias input.files as input.terraform_files in module validator

### DIFF
--- a/scripts/module-validator/main.go
+++ b/scripts/module-validator/main.go
@@ -368,6 +368,16 @@ func main() {
 			inputJSON["files"] = transformedFiles
 		}
 
+		// Alias `files` as `terraform_files` so library policies that read
+		// `input.terraform_files` (composition_policy, no_resources_policy)
+		// receive the same map the collector emitted under `input.files`.
+		// Without this alias both library policies treat collections as empty,
+		// causing composition_policy to always fail and no_resources_policy
+		// to silently pass without inspecting any content.
+		if files, ok := inputJSON["files"].(map[string]interface{}); ok {
+			inputJSON["terraform_files"] = files
+		}
+
 		// Log files found by the collector
 		if files, ok := inputJSON["files"].(map[string]interface{}); ok {
 			logMessage(LevelDebug, "Found %d files in the module", len(files))


### PR DESCRIPTION
## Summary

OPA library policies `composition_policy.rego` and `no_resources_policy.rego`
read `input.terraform_files`, but the module validator only writes
`input.files`. As a result:

- `composition_policy` violation fires unconditionally on every
  collection / reference module (`not has_module_sources` evaluates to
  true when `terraform_files` is undefined).
- `no_resources_policy` silently passes without inspecting any
  content (its `has_resource_blocks` rule iterates the same undefined
  value, so it never finds a violation -- a false negative).

This fix aliases `input.files` as `input.terraform_files` immediately
after the validator's file-path transform, so both library policies
see the map the collector produced.

## Test plan

- [x] `make module-validate MODULE_PATH=skeletons/generic-skeleton MODULE_TYPE=skeleton` passes
- [x] `make module-validate MODULE_PATH=providers/aws/primitives/vpc MODULE_TYPE=primitive` passes
- [x] `make go-format`, `make go-lint`, `make go-unit-test` pass
- [ ] pr-validation.yml all jobs pass
- [ ] merge-approval gate approved