### PR TITLE
fix: exclude examples/ and tests/ from no_resources OPA policy

### DIFF
--- a/policies/opa/terraform/libraries/no_resources_policy.rego
+++ b/policies/opa/terraform/libraries/no_resources_policy.rego
@@ -17,10 +17,16 @@ violation[result] if {
 	}
 }
 
-# Helper to check if any .tf files contain resource blocks
+# Helper to check if any module-root .tf file contains resource blocks.
+# Examples and tests are excluded because example fixtures legitimately
+# need resource blocks to scaffold dependencies (IAM roles, certs, hosted
+# zones) the consumer would supply in production. The same exclusion
+# pattern is used by source_policy for the same reason.
 has_resource_blocks if {
-	files := input.terraform_files
-	count(files) > 0
-	some _, content in files
+	some path in object.keys(input.terraform_files)
+	endswith(path, ".tf")
+	not contains(path, "/examples/")
+	not contains(path, "/tests/")
+	content := input.terraform_files[path]
 	contains(content, "resource \"")
 }

--- a/tests/opa/unit/terraform/libraries/no_resources_policy_test.rego
+++ b/tests/opa/unit/terraform/libraries/no_resources_policy_test.rego
@@ -29,3 +29,27 @@ test_modules_allowed if {
 	violations := policy.violation with input as test_input
 	count(violations) == 0
 }
+
+# Resource blocks inside examples/ are scaffolding for example fixtures and
+# do not violate the no-resources rule on the module itself. The validator
+# normalizes file paths to <module-name>/<rel-path>, so paths land with a
+# leading <module-name>/ component.
+test_examples_resource_blocks_allowed if {
+	test_input := {"terraform_files": {
+		"my-mod/main.tf": "module \"s3\" { source = \"terraform-aws-modules/s3-bucket/aws\" }",
+		"my-mod/examples/basic/main.tf": "resource \"aws_s3_bucket\" \"test\" {}",
+	}}
+	violations := policy.violation with input as test_input
+	count(violations) == 0
+}
+
+# Resource blocks inside tests/ are scaffolding for Terratest fixtures and
+# do not violate the no-resources rule on the module itself.
+test_tests_resource_blocks_allowed if {
+	test_input := {"terraform_files": {
+		"my-mod/main.tf": "module \"s3\" { source = \"terraform-aws-modules/s3-bucket/aws\" }",
+		"my-mod/tests/basic/aux.tf": "resource \"aws_s3_bucket\" \"test\" {}",
+	}}
+	violations := policy.violation with input as test_input
+	count(violations) == 0
+}


### PR DESCRIPTION
## Summary

`no_resources_policy.rego` flagged any `resource "` substring across
**all** `.tf` files, including ones under `examples/<name>/` and
`tests/<name>/`. That breaks every collection / reference / data
module's example fixture: examples must own the dependency resources
(IAM roles, certs, hosted zones, archives) that real consumers
provide externally in production.

Add the same `/examples/` and `/tests/` path exclusions used by
`source_policy`. Updated the unit tests to cover both exclusion
paths and use the validator-normalized
`<module-name>/<rel-path>` form so the test inputs match what the
policy actually sees at runtime.

## Test plan

- [x] `make rego-unit-test` passes (121/121)
- [x] `make rego-lint` passes
- [x] `make module-validate MODULE_PATH=providers/aws/primitives/vpc MODULE_TYPE=primitive` still passes (no_resources is collection-only but library is shared)
- [ ] pr-validation green